### PR TITLE
Add Tagging functionality to Tasks

### DIFF
--- a/src/main/java/skylark/command/Command.java
+++ b/src/main/java/skylark/command/Command.java
@@ -20,6 +20,7 @@ public abstract class Command {
     private static final int MIN_LENGTH_EVENT = 5;
     private static final int MIN_LENGTH_DELETE = 6;
     private static final int MIN_LENGTH_FIND = 5;
+    private static final int MIN_LENGTH_TAG = 5;
 
     /** String representing the input keyed by the user. */
     private final String input;
@@ -60,6 +61,9 @@ public abstract class Command {
         } else if (command.length() >= Command.MIN_LENGTH_FIND
                 && command.startsWith(CommandList.COMMAND_FIND.toString())) {
             return new FindCommand(command);
+        } else if (command.length() >= Command.MIN_LENGTH_TAG
+                && command.startsWith(CommandList.COMMAND_TAG.toString())) {
+            return new TagCommand(command);
         } else {
             return new UnknownCommand(command);
         }
@@ -330,21 +334,61 @@ public abstract class Command {
             if (query.isEmpty()) {
                 throw new SkylarkException("The find query cannot be empty.");
             }
-            String response = "";
-            response += "Here are the matching tasks in your list:";
-            response += System.lineSeparator();
+            StringBuilder response = new StringBuilder();
+            response.append("Here are the matching tasks in your list:");
+            response.append(System.lineSeparator());
             int count = 1;
             for (int i = 0; i < taskList.size(); i++) {
                 Task currentTask = taskList.get(i);
                 if (currentTask.toString().contains(query)) {
-                    response += count
-                            + ". "
-                            + currentTask
-                            + System.lineSeparator();
+                    response.append(count);
+                    response.append(". ");
+                    response.append(currentTask);
+                    response.append(System.lineSeparator());
                     count += 1;
                 }
             }
 
+            return response.toString();
+        }
+    }
+
+    private static class TagCommand extends Command {
+        private static final int POSITION = 4;
+        private static final int POSITION_END = 5;
+
+        /**
+         * Returns a TagCommand object.
+         *
+         * @param input String that is input by the user.
+         */
+        public TagCommand(String input) {
+            super(input);
+        }
+
+        @Override
+        public String run(TaskList taskList) throws SkylarkException {
+            String response;
+            try {
+                String command = super.getInput();
+                int index = Integer.parseInt(command.substring(TagCommand.POSITION, TagCommand.POSITION_END)) - 1;
+                String tag = command.substring(TagCommand.POSITION_END).strip();
+                if (tag.isEmpty()) {
+                    throw new SkylarkException("Sorry, the tag is empty!");
+                }
+                if (taskList.doesIndexExist(index)) {
+                    Task currentTask = taskList.get(index);
+                    currentTask.setTag(tag);
+                    response = "Noted. I've tagged this task:"
+                            + System.lineSeparator()
+                            + currentTask;
+                    taskList.saveToFile();
+                } else {
+                    throw new SkylarkException("Sorry, index does not exist!");
+                }
+            } catch (NumberFormatException numberFormatException) {
+                throw new SkylarkException("Input is not a number!");
+            }
             return response;
         }
     }

--- a/src/main/java/skylark/command/CommandList.java
+++ b/src/main/java/skylark/command/CommandList.java
@@ -4,7 +4,8 @@ package skylark.command;
 public enum CommandList {
     COMMAND_BYE, COMMAND_LIST, COMMAND_DONE,
     COMMAND_UNDONE, COMMAND_DEADLINE,
-    COMMAND_TODO, COMMAND_EVENT, COMMAND_DELETE, COMMAND_FIND;
+    COMMAND_TODO, COMMAND_EVENT, COMMAND_DELETE,
+    COMMAND_FIND, COMMAND_TAG;
 
     @Override
     public String toString() {
@@ -27,6 +28,8 @@ public enum CommandList {
             return "delete";
         case COMMAND_FIND:
             return "find";
+        case COMMAND_TAG:
+            return "tag";
         default:
             throw new IllegalArgumentException();
         }

--- a/src/main/java/skylark/task/Deadline.java
+++ b/src/main/java/skylark/task/Deadline.java
@@ -42,6 +42,25 @@ public class Deadline extends Task {
     }
 
     /**
+     * Returns a Deadline object.
+     * Throws a SkylarkException if the endDate is not parsable.
+     *
+     * @param description Description of the Task
+     * @param endDate     Date in yyyy-MM-dd HHmm format
+     * @param tag         Tag of the Task
+     * @throws SkylarkException If date is not parsable
+     */
+    public Deadline(String description, String endDate, String tag) throws SkylarkException {
+        super(description, tag);
+        assert endDate.length() > 0 : "End Date should not be empty!";
+        try {
+            this.endDate = LocalDateTime.parse(endDate, DateTimeFormatter.ofPattern(inputFormat));
+        } catch (DateTimeParseException dateTimeParseException) {
+            throw new SkylarkException("Cannot parse date");
+        }
+    }
+
+    /**
      * {@inheritDoc}
      * <br><br>
      *

--- a/src/main/java/skylark/task/Event.java
+++ b/src/main/java/skylark/task/Event.java
@@ -36,6 +36,25 @@ public class Event extends Task {
     }
 
     /**
+     * Returns an Event object.
+     * Throws a SkylarkException if the timing is not parsable.
+     *
+     * @param description Description of the Task
+     * @param timing Date in yyyy-MM-dd HHmm format
+     * @param tag    Tag of the Task
+     * @throws SkylarkException If date is not parsable
+     */
+    public Event(String description, String timing, String tag) throws SkylarkException {
+        super(description, tag);
+        assert timing.length() > 0 : "Timing should not be empty!";
+        try {
+            this.timing = LocalDateTime.parse(timing, DateTimeFormatter.ofPattern(inputFormat));
+        } catch (DateTimeParseException dateTimeParseException) {
+            throw new SkylarkException("Cannot parse date");
+        }
+    }
+
+    /**
      * {@inheritDoc}
      * <br><br>
      *

--- a/src/main/java/skylark/task/Task.java
+++ b/src/main/java/skylark/task/Task.java
@@ -8,6 +8,9 @@ public abstract class Task {
     /** Represents whether the task is marked as done. */
     private boolean isDone;
 
+    /** Represents the tagging for the task, if any. */
+    private String tag;
+
     /**
      * Returns a Task object.
      * Initialises the description variable and marks the Task as undone.
@@ -18,6 +21,22 @@ public abstract class Task {
         assert description.length() > 0 : "Description should not be empty!";
         this.description = description;
         this.isDone = false;
+        this.tag = "";
+    }
+
+    /**
+     * Returns a Task object.
+     * Initialises the description variable and marks the Task as undone.
+     *
+     * @param description Description of the task inputted by the user.
+     * @param tag Tag of the task if any
+     */
+    public Task(String description, String tag) {
+        assert description.length() > 0 : "Description should not be empty!";
+        assert tag.length() > 0 : "Tag should not be empty!";
+        this.description = description;
+        this.isDone = false;
+        this.tag = tag;
     }
 
     /**
@@ -53,11 +72,22 @@ public abstract class Task {
     }
 
     /**
+     * Adds a new Tag to the task
+     *
+     * @param newTag New tag of the Task
+     */
+    public void setTag(String newTag) {
+        this.tag = newTag;
+    }
+
+    /**
      * Returns the String representation of a particular task.
      */
     @Override
     public String toString() {
-        return "[" + this.getStatusIcon() + "] " + this.description;
+        return String.format("[%s] %s%s", this.getStatusIcon(),
+                this.description,
+                this.tag.isEmpty() ? "" : " TAG: " + this.tag);
     }
 
     /**
@@ -67,6 +97,9 @@ public abstract class Task {
      * @return String representation of the task that is parsable by the Storage object.
      */
     public String toStringFile() {
-        return String.format("%d | %s", this.getStatusIcon().equals("X") ? 1 : 0, this.getDescription());
+        return String.format("%d | %s%s",
+                this.getStatusIcon().equals("X") ? 1 : 0,
+                this.description,
+                this.tag.isEmpty() ? "" : " | " + this.tag);
     }
 }

--- a/src/main/java/skylark/task/ToDo.java
+++ b/src/main/java/skylark/task/ToDo.java
@@ -15,6 +15,16 @@ public class ToDo extends Task {
     }
 
     /**
+     * Returns a ToDo object.
+     *
+     * @param description Description of the Task
+     * @param tag         Tag of the Task
+     */
+    public ToDo(String description, String tag) {
+        super(description, tag);
+    }
+
+    /**
      * {@inheritDoc}
      * <br><br>
      *

--- a/src/main/java/skylark/utils/Storage.java
+++ b/src/main/java/skylark/utils/Storage.java
@@ -56,20 +56,37 @@ public class Storage {
                     }
 
                     Task currentTask;
+                    String desc = splitStrings[2].strip();
+
                     switch (splitStrings[0]) {
                     case "T":
-                        currentTask = new ToDo(splitStrings[2]);
+                        if (splitStrings.length > 3) {
+                            String tag = splitStrings[3].strip();
+                            currentTask = new ToDo(desc, tag);
+                        } else {
+                            currentTask = new ToDo(desc);
+                        }
                         break;
                     case "D": {
-                        String desc = splitStrings[2];
-                        String endDate = splitStrings[3];
-                        currentTask = new Deadline(desc, endDate);
+                        if (splitStrings.length > 4) {
+                            String endDate = splitStrings[4].strip();
+                            String tag = splitStrings[3].strip();
+                            currentTask = new Deadline(desc, endDate, tag);
+                        } else {
+                            String endDate = splitStrings[3].strip();
+                            currentTask = new Deadline(desc, endDate);
+                        }
                         break;
                     }
                     case "E": {
-                        String desc = splitStrings[2];
-                        String timing = splitStrings[3];
-                        currentTask = new Event(desc, timing);
+                        if (splitStrings.length > 4) {
+                            String timing = splitStrings[4].strip();
+                            String tag = splitStrings[3].strip();
+                            currentTask = new Event(desc, timing, tag);
+                        } else {
+                            String timing = splitStrings[3];
+                            currentTask = new Event(desc, timing);
+                        }
                         break;
                     }
                     default:

--- a/src/test/java/skylark/task/DeadlineTest.java
+++ b/src/test/java/skylark/task/DeadlineTest.java
@@ -23,6 +23,8 @@ public class DeadlineTest {
     public void toString_dateTime_success() throws SkylarkException {
         Deadline task = new Deadline("Make tea", "2019-10-15 1800");
         assertEquals("[D] [ ] Make tea (by: Oct 15 2019)", task.toString());
+        task.markAsDone();
+        assertEquals("[D] [X] Make tea (by: Oct 15 2019)", task.toString());
     }
 
     @Test
@@ -31,5 +33,21 @@ public class DeadlineTest {
         assertEquals("D | 0 | Make tea | 2019-10-15 1800", task.toStringFile());
         task.markAsDone();
         assertEquals("D | 1 | Make tea | 2019-10-15 1800", task.toStringFile());
+    }
+
+    @Test
+    public void toString_dateTimeWTag_success() throws SkylarkException {
+        Deadline task = new Deadline("Make tea", "2019-10-15 1800", "Test tag!");
+        assertEquals("[D] [ ] Make tea TAG: Test tag! (by: Oct 15 2019)", task.toString());
+        task.markAsDone();
+        assertEquals("[D] [X] Make tea TAG: Test tag! (by: Oct 15 2019)", task.toString());
+    }
+
+    @Test
+    public void toStringFile_dateTimeWTag_success() throws SkylarkException {
+        Deadline task = new Deadline("Make tea", "2019-10-15 1800", "Test tag!");
+        assertEquals("D | 0 | Make tea | Test tag! | 2019-10-15 1800", task.toStringFile());
+        task.markAsDone();
+        assertEquals("D | 1 | Make tea | Test tag! | 2019-10-15 1800", task.toStringFile());
     }
 }

--- a/src/test/java/skylark/task/EventTest.java
+++ b/src/test/java/skylark/task/EventTest.java
@@ -23,6 +23,8 @@ public class EventTest {
     public void toString_dateTime_success() throws SkylarkException {
         Event task = new Event("Make tea", "2019-10-15 1800");
         assertEquals("[E] [ ] Make tea (at: Oct 15 2019)", task.toString());
+        task.markAsDone();
+        assertEquals("[E] [X] Make tea (at: Oct 15 2019)", task.toString());
     }
 
     @Test
@@ -31,5 +33,21 @@ public class EventTest {
         assertEquals("E | 0 | Make tea | 2019-10-15 1800", task.toStringFile());
         task.markAsDone();
         assertEquals("E | 1 | Make tea | 2019-10-15 1800", task.toStringFile());
+    }
+
+    @Test
+    public void toString_dateTimeWTag_success() throws SkylarkException {
+        Event task = new Event("Make tea", "2019-10-15 1800", "Test tag!");
+        assertEquals("[E] [ ] Make tea TAG: Test tag! (at: Oct 15 2019)", task.toString());
+        task.markAsDone();
+        assertEquals("[E] [X] Make tea TAG: Test tag! (at: Oct 15 2019)", task.toString());
+    }
+
+    @Test
+    public void toStringFile_dateTimeWTag_success() throws SkylarkException {
+        Event task = new Event("Make tea", "2019-10-15 1800", "Test tag!");
+        assertEquals("E | 0 | Make tea | Test tag! | 2019-10-15 1800", task.toStringFile());
+        task.markAsDone();
+        assertEquals("E | 1 | Make tea | Test tag! | 2019-10-15 1800", task.toStringFile());
     }
 }

--- a/src/test/java/skylark/task/TodoTest.java
+++ b/src/test/java/skylark/task/TodoTest.java
@@ -10,6 +10,8 @@ public class TodoTest {
     public void toString_description_success() {
         ToDo toDoTask = new ToDo("Make tea");
         assertEquals("[T] [ ] Make tea", toDoTask.toString());
+        toDoTask.markAsDone();
+        assertEquals("[T] [X] Make tea", toDoTask.toString());
     }
 
     @Test
@@ -20,6 +22,24 @@ public class TodoTest {
         assertEquals("T | 1 | Make tea", toDoTask.toStringFile());
         toDoTask.markAsUndone();
         assertEquals("T | 0 | Make tea", toDoTask.toStringFile());
+    }
+
+    @Test
+    public void toString_descriptionWTag_success() {
+        ToDo toDoTask = new ToDo("Make tea", "Test tag!");
+        assertEquals("[T] [ ] Make tea TAG: Test tag!", toDoTask.toString());
+        toDoTask.markAsDone();
+        assertEquals("[T] [X] Make tea TAG: Test tag!", toDoTask.toString());
+    }
+
+    @Test
+    public void toStringFile_descriptionWTag_success() {
+        ToDo toDoTask = new ToDo("Make tea", "Test tag!");
+        assertEquals("T | 0 | Make tea | Test tag!", toDoTask.toStringFile());
+        toDoTask.markAsDone();
+        assertEquals("T | 1 | Make tea | Test tag!", toDoTask.toStringFile());
+        toDoTask.markAsUndone();
+        assertEquals("T | 0 | Make tea | Test tag!", toDoTask.toStringFile());
     }
 
     @Test
@@ -40,5 +60,15 @@ public class TodoTest {
         assertEquals("Make coffee", toDoTask2.getDescription());
         ToDo toDoTask3 = new ToDo("Make cereal");
         assertEquals("Make cereal", toDoTask3.getDescription());
+    }
+
+    @Test
+    public void setTag_tag_success() {
+        ToDo toDoTask = new ToDo("Make tea", "Old tag!");
+        assertEquals("[T] [ ] Make tea TAG: Old tag!", toDoTask.toString());
+        toDoTask.setTag("New tag!");
+        assertEquals("[T] [ ] Make tea TAG: New tag!", toDoTask.toString());
+        toDoTask.setTag("New tag again!");
+        assertEquals("[T] [ ] Make tea TAG: New tag again!", toDoTask.toString());
     }
 }


### PR DESCRIPTION
Task Class now has a new parameter: tag that represents the tagging allocated to each Task

The user is now able to add tags to a particular task using the `tag INDEX TAG` command, specifying the index of the task in the existing list, as well as the tags to be applied. 

Any old tags would be overridden in the current iteration.